### PR TITLE
DOCS: fix broken wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # WELCOME TO OPEN SOLO #
 
-[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/Pedals2Paddles/OpenSolo/wiki)
+[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/OpenSolo/OpenSolo/wiki)

--- a/artoo/ReadMe.md
+++ b/artoo/ReadMe.md
@@ -4,4 +4,4 @@ The controller's STM32 is the hardware behind the buttons, sticks, and display. 
 
 Some compiled versions of the Artoo STM32 firmware can be found in the [/Firmware/Artoo STM32](/Firmware/Artoo) directory.
 
-[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/Pedals2Paddles/OpenSolo/wiki/Artoo-STM32)
+[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/OpenSolo/OpenSolo/wiki/Artoo-STM32)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,3 +1,3 @@
 # Open Solo Releases For Users #
 
-[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/Pedals2Paddles/OpenSolo/wiki)
+[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/OpenSolo/OpenSolo/wiki)

--- a/solo-builder/README.md
+++ b/solo-builder/README.md
@@ -1,4 +1,4 @@
 # Solo Builder #
 The solo-builder will create file system images for the Solo's IMX and the controller's IMX. The Open Solo vagrant virual machine is used for the build environment. The vagrant VM used for solo-builder is also used for the Artoo STM32 firmware builder. So if you already installed and setup the VM for artoo, you can skip right to executing the build.
 
-[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/Pedals2Paddles/OpenSolo/wiki/Solo-Builder)
+[Go to the Open Solo github Wiki for Open Solo documentation and instructions](https://github.com/OpenSolo/OpenSolo/wiki/Solo-Builder)


### PR DESCRIPTION
Pedals2Paddles fork does not have a wiki. Keep full urls as relative wiki urls don't work in github.